### PR TITLE
feat: enable CORS for frontend development

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -2,11 +2,24 @@
 from typing import List
 
 from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 import yfinance as yf
 
 app = FastAPI(title="Stock Viewer API")
 
+# フロント（Vite）が動いている URL を許可
+origins = [
+    "http://localhost:5173",
+]
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=origins,          # 許可するオリジン
+    allow_credentials=True,
+    allow_methods=["*"],            # GET, POST, OPTIONS など全て
+    allow_headers=["*"],            # Authorization などを許可
+)
 
 @app.get("/health")
 def health():


### PR DESCRIPTION
main.pyにviteの開発サーバー(`http://localhost:5173`)からのリクエストを許可するためのCORS設定をした。