### PR TITLE
refactor: normalize API endpoint paths by removing leading slashes

### DIFF
--- a/backend/routers/favorites.py
+++ b/backend/routers/favorites.py
@@ -6,7 +6,7 @@ from services import favorites_service, auth_service
 
 router = APIRouter(prefix="/favorites", tags=["favorites"])
 
-@router.get("/", response_model=FavoritesResponse)
+@router.get("", response_model=FavoritesResponse)
 def get_favorites(
     current_user: UserRead = Depends(auth_service.get_current_user),
 ):
@@ -17,7 +17,7 @@ def get_favorites(
     return FavoritesResponse(user_id=current_user.id, symbols=symbols)
 
 
-@router.post("/", response_model=FavoritesResponse)
+@router.post("", response_model=FavoritesResponse)
 def toggle_favorite(
     body: FavoriteRequest,
     current_user: UserRead = Depends(auth_service.get_current_user),


### PR DESCRIPTION
favorite エンドポイントのスラッシュを取り除いた